### PR TITLE
Fix supervisor installation in Centos 7 Dockerfile

### DIFF
--- a/docker/dist/Dockerfile.dist.centos7
+++ b/docker/dist/Dockerfile.dist.centos7
@@ -5,7 +5,9 @@ RUN yum -y install python; yum clean all
 RUN yum -y install unzip; yum clean all
 RUN yum -y install which; yum clean all
 RUN yum -y install curl; yum clean all
-RUN apt-get -y install supervisor; apt-get clean all
+RUN yum -y install python-setuptools; yum clean all
+RUN easy_install supervisor
+RUN echo_supervisord_conf > /etc/supervisord.conf
 
 RUN yum -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel; yum clean all
 


### PR DESCRIPTION
Fixes #2965

I tried the simpler `yum install supervisor` but the configured repos don't contain it. This is the simplest solution I found. 